### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/modules/phone_lookup/phone_lookup.py
+++ b/modules/phone_lookup/phone_lookup.py
@@ -60,9 +60,8 @@ def phone_lookup(phone_number):
         with open(filename, "w") as json_file:
             json.dump(structured_data, json_file, indent=4)
 
-        masked_number = mask_phone_number(phone_number)
         logging.info(
-            f"Phone lookup and parsing successful for: {masked_number}, results saved in {filename}"
+            f"Phone lookup and parsing successful, results saved in {filename}"
         )
         return structured_data
 


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/Auton-OSINT/security/code-scanning/5](https://github.com/Into-The-Grey/Auton-OSINT/security/code-scanning/5)

To fix the problem, we should avoid logging the phone number altogether, even if it is masked. Instead, we can log a generic message indicating that the phone lookup and parsing were successful without including the phone number. This way, we maintain the functionality of logging the success of the operation without exposing any sensitive information.

- Remove the phone number from the log message on line 65.
- Update the log message to indicate success without including the phone number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
