### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/modules/phone_lookup/phone_lookup.py
+++ b/modules/phone_lookup/phone_lookup.py
@@ -39,8 +39,7 @@ def phone_lookup(phone_number):
     ]
 
     try:
-        masked_phone_number = mask_phone_number(phone_number)
-        logging.info(f"Initiating phone lookup for: {masked_phone_number}")
+        logging.info("Initiating phone lookup.")
         result = subprocess.run(
             command, capture_output=True, text=True, timeout=config["timeout"]
         )

--- a/modules/phone_lookup/phone_lookup.py
+++ b/modules/phone_lookup/phone_lookup.py
@@ -39,7 +39,8 @@ def phone_lookup(phone_number):
     ]
 
     try:
-        logging.info(f"Initiating phone lookup for: {phone_number}")
+        masked_phone_number = mask_phone_number(phone_number)
+        logging.info(f"Initiating phone lookup for: {masked_phone_number}")
         result = subprocess.run(
             command, capture_output=True, text=True, timeout=config["timeout"]
         )


### PR DESCRIPTION
Potential fix for [https://github.com/Into-The-Grey/Auton-OSINT/security/code-scanning/2](https://github.com/Into-The-Grey/Auton-OSINT/security/code-scanning/2)

To fix the problem, we should avoid logging the phone number in clear text. Instead, we can mask the phone number before logging it. This way, the logs will not contain sensitive information, but we can still retain enough information to be useful for debugging purposes.

- We will use the existing `mask_phone_number` function to mask the phone number before logging it.
- We will modify the logging statement on line 42 to log the masked phone number instead of the full phone number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
